### PR TITLE
Implement automatic and improved Celeste field offset calculation

### DIFF
--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -271,6 +271,7 @@ namespace LiveSplit.Celeste {
                         case LogObject.CurrentSplit: curr = currentSplit.ToString(); break;
                         case LogObject.Pointers: curr = mem.RAMPointers(); break;
                         case LogObject.PointerVersion: curr = mem.RAMPointerVersion(); break;
+                        case LogObject.CelesteFieldOffs: curr = mem.CelesteFieldOffs().ToString("X"); break;
                         case LogObject.GameTime: curr = mem.GameTime().ToString("0"); break;
                         case LogObject.LevelTime: curr = mem.LevelTime().ToString("0"); break;
                         case LogObject.ShowInputUI: curr = mem.ShowInputUI().ToString(); break;
@@ -293,7 +294,7 @@ namespace LiveSplit.Celeste {
                     if (string.IsNullOrEmpty(prev)) { prev = string.Empty; }
                     if (string.IsNullOrEmpty(curr)) { curr = string.Empty; }
                     if (!prev.Equals(curr)) {
-                        WriteLog(DateTime.Now.ToString(@"HH\:mm\:ss.fff") + (Model != null ? " | " + Model.CurrentState.CurrentTime.RealTime.Value.ToString("G").Substring(3, 11) : "") + ": " + key.ToString() + ": ".PadRight(16 - key.ToString().Length, ' ') + prev.PadLeft(25, ' ') + " -> " + curr);
+                        WriteLog(DateTime.Now.ToString(@"HH\:mm\:ss.fff") + (Model != null ? " | " + Model.CurrentState.CurrentTime.RealTime.Value.ToString("G").Substring(3, 11) : "") + ": " + key.ToString() + ": ".PadRight(18 - key.ToString().Length, ' ') + prev.PadLeft(25, ' ') + " -> " + curr);
 
                         currentValues[key] = curr;
                     }

--- a/SplitterObjects.cs
+++ b/SplitterObjects.cs
@@ -5,6 +5,7 @@ namespace LiveSplit.Celeste {
         CurrentSplit,
         Pointers,
         PointerVersion,
+        CelesteFieldOffs,
         GameTime,
         LevelTime,
         ShowInputUI,


### PR DESCRIPTION
This PR replaces the hardcoded per version field offsets with a method that gets the offset to the `Celeste.Instance.Title` field automatically (it should always have the value `Celeste`), and then performs all other field reads relative to that (f.e. `AutosplitterInfo` is @ `CelesteFieldOffs() + 0x1c`).  

I've decided to do this because there's a FNA update that fixes input latency and frame pacing that adds fields to the `Game` class - thus shifting all fields - *without changing the signature found by `OpenGL14`*.

Fun fact: when starting the game with dnSpy, the autosplitter finds the signature but the JIT compiler emits slightly different native code past that, breaking the assumption that there's a pointer to the instance field at `sig + 99`. I wonder if this could also be replicated in non-debugging environments if memory layout were at play.

This has worked fine in my personal testing with XNA, Celeste old FNA and Celeste new FNA.

In the absolute worst case, it should still fall back to the old hardcoded offsets while still retrying to find the "Celeste" class field offset (actually `Engine` but kept as Celeste for clarity).