### PR TITLE
Fix auto splitter doesn't automatically start when entering a new save file on Everest (EverestAPI/Everest#443)

### DIFF
--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -79,7 +79,7 @@ namespace LiveSplit.Celeste {
                 } else if (!settings.ILSplits) {
                     bool showInputUI = mem.ShowInputUI();
 
-                    shouldSplit = !showInputUI && lastShowInputUI && mem.MenuType() == Menu.FileSelect;
+                    shouldSplit = !showInputUI && lastShowInputUI && mem.EnteringFirstChapter();
 
                     lastShowInputUI = showInputUI;
                 } else {
@@ -275,12 +275,12 @@ namespace LiveSplit.Celeste {
                         case LogObject.GameTime: curr = mem.GameTime().ToString("0"); break;
                         case LogObject.LevelTime: curr = mem.LevelTime().ToString("0"); break;
                         case LogObject.ShowInputUI: curr = mem.ShowInputUI().ToString(); break;
+                        case LogObject.EnteringFirstChapter: curr = mem.EnteringFirstChapter().ToString(); break;
                         case LogObject.Started: curr = mem.ChapterStarted().ToString(); break;
                         case LogObject.Completed: curr = mem.ChapterCompleted().ToString(); break;
                         case LogObject.AreaID: curr = mem.AreaID().ToString(); break;
                         case LogObject.AreaMode: curr = mem.AreaDifficulty().ToString(); break;
                         case LogObject.LevelName: curr = mem.LevelName(); break;
-                        case LogObject.Menu: curr = mem.MenuType().ToString(); break;
                         case LogObject.Strawberries: curr = mem.Strawberries().ToString(); break;
                         case LogObject.Cassettes: curr = mem.Cassettes().ToString(); break;
                         case LogObject.HeartGems: curr = mem.HeartGems().ToString(); break;
@@ -294,7 +294,7 @@ namespace LiveSplit.Celeste {
                     if (string.IsNullOrEmpty(prev)) { prev = string.Empty; }
                     if (string.IsNullOrEmpty(curr)) { curr = string.Empty; }
                     if (!prev.Equals(curr)) {
-                        WriteLog(DateTime.Now.ToString(@"HH\:mm\:ss.fff") + (Model != null ? " | " + Model.CurrentState.CurrentTime.RealTime.Value.ToString("G").Substring(3, 11) : "") + ": " + key.ToString() + ": ".PadRight(18 - key.ToString().Length, ' ') + prev.PadLeft(25, ' ') + " -> " + curr);
+                        WriteLog(DateTime.Now.ToString(@"HH\:mm\:ss.fff") + (Model != null ? " | " + Model.CurrentState.CurrentTime.RealTime.Value.ToString("G").Substring(3, 11) : "") + ": " + key.ToString() + ": ".PadRight(22 - key.ToString().Length, ' ') + prev.PadLeft(25, ' ') + " -> " + curr);
 
                         currentValues[key] = curr;
                     }

--- a/SplitterMemory.cs
+++ b/SplitterMemory.cs
@@ -114,14 +114,16 @@ namespace LiveSplit.Celeste {
             }
             return false;
         }
-        public Menu MenuType() {
+        public bool EnteringFirstChapter() {
             //Celeste.Instance.scene.MethodTable.TypeSize
             int size = Celeste.Read<int>(Program, 0x0, CelesteFieldOffs() + 0x8, 0x0, 0x4);
             if (size == 100) {
-                //((Overworld)Celeste.Instance.scene).current.MethodTable.TypeSize
-                return (Menu)Celeste.Read<int>(Program, 0x0, CelesteFieldOffs() + 0x8, 0x30, 0x0, 0x4);
+                //((Overworld)Celeste.Instance.scene).Maddy.MethodTable.TypeSize
+                int maddy3DSize = Celeste.Read<int>(Program, 0x0, CelesteFieldOffs() + 0x8, 0x4C, 0x0, 0x4);
+                //((Overworld)Celeste.Instance.scene).Maddy.Disabled
+                return Celeste.Read<bool>(Program, 0x0, CelesteFieldOffs() + 0x8, 0x4C, maddy3DSize - 0x1B);
             }
-            return Menu.InGame;
+            return false;
         }
         public bool HookProcess() {
             IsHooked = Program != null && !Program.HasExited;

--- a/SplitterObjects.cs
+++ b/SplitterObjects.cs
@@ -9,7 +9,7 @@ namespace LiveSplit.Celeste {
         GameTime,
         LevelTime,
         ShowInputUI,
-        Menu,
+        EnteringFirstChapter,
         Completed,
         Started,
         AreaID,
@@ -39,15 +39,6 @@ namespace LiveSplit.Celeste {
         ASide = 0,
         BSide = 1,
         CSide = 2
-    }
-    public enum Menu {
-        InGame = 0,
-        Intro = 14,
-        FileSelect = 60,
-        MainMenu = 64,
-        ChapterSelect = 80,
-        ChapterPanel = 168,
-        FileRename = 180
     }
     public enum SplitType {
         [Description("Manual Split (Not Automatic)")]

--- a/SplitterTest.cs
+++ b/SplitterTest.cs
@@ -63,13 +63,11 @@ namespace LiveSplit.Celeste {
 						//case LogObject.GameTime: curr = mem.GameTime().ToString("0"); break;
 						//case LogObject.LevelTime: curr = mem.LevelTime().ToString("0"); break;
 						case LogObject.ShowInputUI: curr = mem.ShowInputUI().ToString(); break;
+                        case LogObject.EnteringFirstChapter: curr = mem.EnteringFirstChapter().ToString(); break;
 						case LogObject.Started: curr = mem.ChapterStarted().ToString(); break;
-						case LogObject.Completed: curr = mem.LevelCompleted().ToString(); break;
-						case LogObject.Deaths: curr = mem.Deaths().ToString(); break;
 						case LogObject.AreaID: curr = mem.AreaID().ToString(); break;
 						case LogObject.AreaMode: curr = mem.AreaDifficulty().ToString(); break;
 						case LogObject.LevelName: curr = mem.LevelName(); break;
-						case LogObject.Menu: curr = mem.MenuType().ToString(); break;
 						case LogObject.Strawberries: curr = mem.Strawberries().ToString(); break;
 						case LogObject.Cassettes: curr = mem.Cassettes().ToString(); break;
 						case LogObject.HeartGems: curr = mem.HeartGems().ToString(); break;
@@ -79,7 +77,7 @@ namespace LiveSplit.Celeste {
 					if (string.IsNullOrEmpty(prev)) { prev = string.Empty; }
 					if (string.IsNullOrEmpty(curr)) { curr = string.Empty; }
 					if (!prev.Equals(curr)) {
-						WriteLog(DateTime.Now.ToString(@"HH\:mm\:ss.fff") + ": " + key.ToString() + ": ".PadRight(16 - key.ToString().Length, ' ') + prev.PadLeft(25, ' ') + " -> " + curr);
+						WriteLog(DateTime.Now.ToString(@"HH\:mm\:ss.fff") + ": " + key.ToString() + ": ".PadRight(22 - key.ToString().Length, ' ') + prev.PadLeft(25, ' ') + " -> " + curr);
 
 						currentValues[key] = curr;
 					}

--- a/SplitterTest.cs
+++ b/SplitterTest.cs
@@ -63,7 +63,7 @@ namespace LiveSplit.Celeste {
 						//case LogObject.GameTime: curr = mem.GameTime().ToString("0"); break;
 						//case LogObject.LevelTime: curr = mem.LevelTime().ToString("0"); break;
 						case LogObject.ShowInputUI: curr = mem.ShowInputUI().ToString(); break;
-                        case LogObject.EnteringFirstChapter: curr = mem.EnteringFirstChapter().ToString(); break;
+						case LogObject.EnteringFirstChapter: curr = mem.EnteringFirstChapter().ToString(); break;
 						case LogObject.Started: curr = mem.ChapterStarted().ToString(); break;
 						case LogObject.AreaID: curr = mem.AreaID().ToString(); break;
 						case LogObject.AreaMode: curr = mem.AreaDifficulty().ToString(); break;


### PR DESCRIPTION
https://github.com/EverestAPI/Everest/commit/bd5932ecd3abc091e516cf7e312331d2d59d4926
Because Everest has added two fields to the Entity in the recent update, the method to determine if the game is in the `OuiFileSelect` is not working.
Now it use `overworld.Maddy.Disabled` to determine if entring first chapter from new file