### PR TITLE
Fix issues with cassette/heart splits + add tooltips to checkbox settings

### DIFF
--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -153,24 +153,26 @@ namespace LiveSplit.Celeste {
                         default:
                             int cassettes = mem.Cassettes();
                             int heartGems = mem.HeartGems();
+                            bool chapterCassette = mem.ChapterCassetteCollected();
+                            bool chapterHeart = mem.ChapterHeartCollected();
                             switch (split.Type) {
-                                case SplitType.HeartGemAny: shouldSplit = heartGems == lastHeartGems + 1; break;
-                                case SplitType.Chapter1Cassette: shouldSplit = areaID == Area.ForsakenCity && cassettes == lastCassettes + 1; break;
-                                case SplitType.Chapter1HeartGem: shouldSplit = areaID == Area.ForsakenCity && heartGems == lastHeartGems + 1; break;
-                                case SplitType.Chapter2Cassette: shouldSplit = areaID == Area.OldSite && cassettes == lastCassettes + 1; break;
-                                case SplitType.Chapter2HeartGem: shouldSplit = areaID == Area.OldSite && heartGems == lastHeartGems + 1; break;
-                                case SplitType.Chapter3Cassette: shouldSplit = areaID == Area.CelestialResort && cassettes == lastCassettes + 1; break;
-                                case SplitType.Chapter3HeartGem: shouldSplit = areaID == Area.CelestialResort && heartGems == lastHeartGems + 1; break;
-                                case SplitType.Chapter4Cassette: shouldSplit = areaID == Area.GoldenRidge && cassettes == lastCassettes + 1; break;
-                                case SplitType.Chapter4HeartGem: shouldSplit = areaID == Area.GoldenRidge && heartGems == lastHeartGems + 1; break;
-                                case SplitType.Chapter5Cassette: shouldSplit = areaID == Area.MirrorTemple && cassettes == lastCassettes + 1; break;
-                                case SplitType.Chapter5HeartGem: shouldSplit = areaID == Area.MirrorTemple && heartGems == lastHeartGems + 1; break;
-                                case SplitType.Chapter6Cassette: shouldSplit = areaID == Area.Reflection && cassettes == lastCassettes + 1; break;
-                                case SplitType.Chapter6HeartGem: shouldSplit = areaID == Area.Reflection && heartGems == lastHeartGems + 1; break;
-                                case SplitType.Chapter7Cassette: shouldSplit = areaID == Area.TheSummit && cassettes == lastCassettes + 1; break;
-                                case SplitType.Chapter7HeartGem: shouldSplit = areaID == Area.TheSummit && heartGems == lastHeartGems + 1; break;
-                                case SplitType.Chapter8Cassette: shouldSplit = areaID == Area.Core && cassettes == lastCassettes + 1; break;
-                                case SplitType.Chapter8HeartGem: shouldSplit = areaID == Area.Core && heartGems == lastHeartGems + 1; break;
+                                case SplitType.HeartGemAny: shouldSplit = (settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1; break;
+                                case SplitType.Chapter1Cassette: shouldSplit = areaID == Area.ForsakenCity && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                                case SplitType.Chapter1HeartGem: shouldSplit = areaID == Area.ForsakenCity && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                                case SplitType.Chapter2Cassette: shouldSplit = areaID == Area.OldSite && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                                case SplitType.Chapter2HeartGem: shouldSplit = areaID == Area.OldSite && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                                case SplitType.Chapter3Cassette: shouldSplit = areaID == Area.CelestialResort && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                                case SplitType.Chapter3HeartGem: shouldSplit = areaID == Area.CelestialResort && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                                case SplitType.Chapter4Cassette: shouldSplit = areaID == Area.GoldenRidge && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                                case SplitType.Chapter4HeartGem: shouldSplit = areaID == Area.GoldenRidge && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                                case SplitType.Chapter5Cassette: shouldSplit = areaID == Area.MirrorTemple && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                                case SplitType.Chapter5HeartGem: shouldSplit = areaID == Area.MirrorTemple && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                                case SplitType.Chapter6Cassette: shouldSplit = areaID == Area.Reflection && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                                case SplitType.Chapter6HeartGem: shouldSplit = areaID == Area.Reflection && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                                case SplitType.Chapter7Cassette: shouldSplit = areaID == Area.TheSummit && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                                case SplitType.Chapter7HeartGem: shouldSplit = areaID == Area.TheSummit && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                                case SplitType.Chapter8Cassette: shouldSplit = areaID == Area.Core && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                                case SplitType.Chapter8HeartGem: shouldSplit = areaID == Area.Core && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
                             }
                             lastCassettes = cassettes;
                             lastHeartGems = heartGems;
@@ -283,7 +285,9 @@ namespace LiveSplit.Celeste {
                         case LogObject.LevelName: curr = mem.LevelName(); break;
                         case LogObject.Strawberries: curr = mem.Strawberries().ToString(); break;
                         case LogObject.Cassettes: curr = mem.Cassettes().ToString(); break;
+                        case LogObject.ChapterCassette: curr = mem.ChapterCassetteCollected().ToString(); break;
                         case LogObject.HeartGems: curr = mem.HeartGems().ToString(); break;
+                        case LogObject.ChapterHeart: curr = mem.ChapterHeartCollected().ToString(); break;
                         case LogObject.HighPriority:
                             bool? highPriority = mem.IsHighPriority();
                             curr = highPriority.HasValue ? highPriority.Value.ToString() : "N/A";

--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -97,6 +97,10 @@ namespace LiveSplit.Celeste {
                 SplitInfo split = currentSplit + addAmount < settings.Splits.Count ? settings.Splits[currentSplit + addAmount] : null;
                 string levelName = mem.LevelName();
                 if (string.IsNullOrEmpty(levelName) && areaID != Area.Menu) { levelName = lastLevelName; }
+                int cassettes = mem.Cassettes();
+                int heartGems = mem.HeartGems();
+                bool chapterCassette = mem.ChapterCassetteCollected();
+                bool chapterHeart = mem.ChapterHeartCollected();
 
                 if (split != null && split.Type != SplitType.Manual) {
                     switch (split.Type) {
@@ -150,34 +154,26 @@ namespace LiveSplit.Celeste {
                         case SplitType.Chapter9Checkpoint6: shouldSplit = areaID == Area.Farewell && levelName == "i-00"; break;
                         case SplitType.Chapter9Checkpoint7: shouldSplit = areaID == Area.Farewell && levelName == "j-00"; break;
                         case SplitType.Chapter9Checkpoint8: shouldSplit = areaID == Area.Farewell && levelName == "j-16"; break;
-                        default:
-                            int cassettes = mem.Cassettes();
-                            int heartGems = mem.HeartGems();
-                            bool chapterCassette = mem.ChapterCassetteCollected();
-                            bool chapterHeart = mem.ChapterHeartCollected();
-                            switch (split.Type) {
-                                case SplitType.HeartGemAny: shouldSplit = (settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1; break;
-                                case SplitType.Chapter1Cassette: shouldSplit = areaID == Area.ForsakenCity && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                                case SplitType.Chapter1HeartGem: shouldSplit = areaID == Area.ForsakenCity && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                                case SplitType.Chapter2Cassette: shouldSplit = areaID == Area.OldSite && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                                case SplitType.Chapter2HeartGem: shouldSplit = areaID == Area.OldSite && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                                case SplitType.Chapter3Cassette: shouldSplit = areaID == Area.CelestialResort && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                                case SplitType.Chapter3HeartGem: shouldSplit = areaID == Area.CelestialResort && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                                case SplitType.Chapter4Cassette: shouldSplit = areaID == Area.GoldenRidge && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                                case SplitType.Chapter4HeartGem: shouldSplit = areaID == Area.GoldenRidge && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                                case SplitType.Chapter5Cassette: shouldSplit = areaID == Area.MirrorTemple && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                                case SplitType.Chapter5HeartGem: shouldSplit = areaID == Area.MirrorTemple && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                                case SplitType.Chapter6Cassette: shouldSplit = areaID == Area.Reflection && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                                case SplitType.Chapter6HeartGem: shouldSplit = areaID == Area.Reflection && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                                case SplitType.Chapter7Cassette: shouldSplit = areaID == Area.TheSummit && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                                case SplitType.Chapter7HeartGem: shouldSplit = areaID == Area.TheSummit && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                                case SplitType.Chapter8Cassette: shouldSplit = areaID == Area.Core && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                                case SplitType.Chapter8HeartGem: shouldSplit = areaID == Area.Core && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                            }
-                            lastCassettes = cassettes;
-                            lastHeartGems = heartGems;
-                            break;
+                        case SplitType.HeartGemAny: shouldSplit = (settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1; break;
+                        case SplitType.Chapter1Cassette: shouldSplit = areaID == Area.ForsakenCity && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter1HeartGem: shouldSplit = areaID == Area.ForsakenCity && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter2Cassette: shouldSplit = areaID == Area.OldSite && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter2HeartGem: shouldSplit = areaID == Area.OldSite && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter3Cassette: shouldSplit = areaID == Area.CelestialResort && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter3HeartGem: shouldSplit = areaID == Area.CelestialResort && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter4Cassette: shouldSplit = areaID == Area.GoldenRidge && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter4HeartGem: shouldSplit = areaID == Area.GoldenRidge && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter5Cassette: shouldSplit = areaID == Area.MirrorTemple && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter5HeartGem: shouldSplit = areaID == Area.MirrorTemple && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter6Cassette: shouldSplit = areaID == Area.Reflection && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter6HeartGem: shouldSplit = areaID == Area.Reflection && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter7Cassette: shouldSplit = areaID == Area.TheSummit && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter7HeartGem: shouldSplit = areaID == Area.TheSummit && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter8Cassette: shouldSplit = areaID == Area.Core && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter8HeartGem: shouldSplit = areaID == Area.Core && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
                     }
+                    lastCassettes = cassettes;
+                    lastHeartGems = heartGems;
                 } else if (split == null && Model.CurrentState.Run.Count == 1) {
                     if (levelName == levelStarted && elapsed - levelTimer < 2.5) {
                         levelStarted = lastLevelName;

--- a/SplitterMemory.cs
+++ b/SplitterMemory.cs
@@ -101,9 +101,17 @@ namespace LiveSplit.Celeste {
             //Celeste.Instance.AutosplitterInfo.FileCassettes
             return Celeste.Read<int>(Program, 0x0, CelesteFieldOffs() + 0x1c, 0x28);
         }
+        public bool ChapterCassetteCollected() {
+            //Celeste.Instance.AutosplitterInfo.ChapterCassette
+            return Celeste.Read<bool>(Program, 0x0, CelesteFieldOffs() + 0x1c, 0x33);
+        }
         public int HeartGems() {
             //Celeste.Instance.AutosplitterInfo.FileHearts
             return Celeste.Read<int>(Program, 0x0, CelesteFieldOffs() + 0x1c, 0x2c);
+        }
+        public bool ChapterHeartCollected() {
+            //Celeste.Instance.AutosplitterInfo.ChapterHeart
+            return Celeste.Read<bool>(Program, 0x0, CelesteFieldOffs()+ 0x1c, 0x34);
         }
         public bool ShowInputUI() {
             //Celeste.Instance.scene.MethodTable.TypeSize

--- a/SplitterObjects.cs
+++ b/SplitterObjects.cs
@@ -18,6 +18,8 @@ namespace LiveSplit.Celeste {
         Strawberries,
         HeartGems,
         Cassettes,
+        ChapterCassette,
+        ChapterHeart,
         HighPriority
     }
     public enum Area {

--- a/SplitterSettings.Designer.cs
+++ b/SplitterSettings.Designer.cs
@@ -27,10 +27,11 @@
             this.flowMain = new System.Windows.Forms.FlowLayoutPanel();
             this.flowOptions = new System.Windows.Forms.FlowLayoutPanel();
             this.chkAutoReset = new System.Windows.Forms.CheckBox();
+            this.chkHighPriority = new System.Windows.Forms.CheckBox();
             this.btnChapterSplits = new System.Windows.Forms.Button();
             this.btnChapterCheckpointSplits = new System.Windows.Forms.Button();
             this.btnABCSides = new System.Windows.Forms.Button();
-            this.chkHighPriority = new System.Windows.Forms.CheckBox();
+            this.toolTip1 = new System.Windows.Forms.ToolTip();
             this.flowMain.SuspendLayout();
             this.flowOptions.SuspendLayout();
             this.SuspendLayout();
@@ -38,7 +39,8 @@
             // btnAddSplit
             // 
             this.btnAddSplit.AutoSize = true;
-            this.btnAddSplit.Location = new System.Drawing.Point(3, 3);
+            this.btnAddSplit.Location = new System.Drawing.Point(6, 6);
+            this.btnAddSplit.Margin = new System.Windows.Forms.Padding(6);
             this.btnAddSplit.Name = "btnAddSplit";
             this.btnAddSplit.Size = new System.Drawing.Size(59, 23);
             this.btnAddSplit.TabIndex = 0;
@@ -57,7 +59,7 @@
             this.flowMain.Location = new System.Drawing.Point(0, 0);
             this.flowMain.Margin = new System.Windows.Forms.Padding(0);
             this.flowMain.Name = "flowMain";
-            this.flowMain.Size = new System.Drawing.Size(442, 29);
+            this.flowMain.Size = new System.Drawing.Size(874, 56);
             this.flowMain.TabIndex = 0;
             this.flowMain.WrapContents = false;
             this.flowMain.DragDrop += new System.Windows.Forms.DragEventHandler(this.flowMain_DragDrop);
@@ -76,25 +78,41 @@
             this.flowOptions.Location = new System.Drawing.Point(0, 0);
             this.flowOptions.Margin = new System.Windows.Forms.Padding(0);
             this.flowOptions.Name = "flowOptions";
-            this.flowOptions.Size = new System.Drawing.Size(442, 29);
+            this.flowOptions.Size = new System.Drawing.Size(874, 56);
             this.flowOptions.TabIndex = 0;
             // 
             // chkAutoReset
             // 
-            this.chkAutoReset.Location = new System.Drawing.Point(68, 3);
+            this.chkAutoReset.Location = new System.Drawing.Point(126, 6);
+            this.chkAutoReset.Margin = new System.Windows.Forms.Padding(6);
             this.chkAutoReset.Name = "chkAutoReset";
-            this.chkAutoReset.Size = new System.Drawing.Size(96, 23);
+            this.chkAutoReset.Size = new System.Drawing.Size(192, 44);
             this.chkAutoReset.TabIndex = 5;
             this.chkAutoReset.TabStop = false;
             this.chkAutoReset.Text = "Auto Reset ILs";
+            this.toolTip1.SetToolTip(this.chkAutoReset, "Reset IL splits if restarting or exiting the chapter (incl. save and quit)");
             this.chkAutoReset.UseVisualStyleBackColor = true;
             this.chkAutoReset.CheckedChanged += new System.EventHandler(this.ControlChanged);
             // 
+            // chkHighPriority
+            // 
+            this.chkHighPriority.Location = new System.Drawing.Point(330, 6);
+            this.chkHighPriority.Margin = new System.Windows.Forms.Padding(6);
+            this.chkHighPriority.Name = "chkHighPriority";
+            this.chkHighPriority.Size = new System.Drawing.Size(166, 44);
+            this.chkHighPriority.TabIndex = 6;
+            this.chkHighPriority.TabStop = false;
+            this.chkHighPriority.Text = "High Priority";
+            this.toolTip1.SetToolTip(this.chkHighPriority, "Set Celeste.exe\'s task priority to High");
+            this.chkHighPriority.UseVisualStyleBackColor = true;
+            this.chkHighPriority.CheckedChanged += new System.EventHandler(this.ControlChanged);
+            // 
             // btnChapterSplits
             // 
-            this.btnChapterSplits.Location = new System.Drawing.Point(259, 3);
+            this.btnChapterSplits.Location = new System.Drawing.Point(508, 6);
+            this.btnChapterSplits.Margin = new System.Windows.Forms.Padding(6);
             this.btnChapterSplits.Name = "btnChapterSplits";
-            this.btnChapterSplits.Size = new System.Drawing.Size(54, 23);
+            this.btnChapterSplits.Size = new System.Drawing.Size(108, 44);
             this.btnChapterSplits.TabIndex = 1;
             this.btnChapterSplits.TabStop = false;
             this.btnChapterSplits.Text = "Chapter";
@@ -103,9 +121,10 @@
             // 
             // btnChapterCheckpointSplits
             // 
-            this.btnChapterCheckpointSplits.Location = new System.Drawing.Point(319, 3);
+            this.btnChapterCheckpointSplits.Location = new System.Drawing.Point(628, 6);
+            this.btnChapterCheckpointSplits.Margin = new System.Windows.Forms.Padding(6);
             this.btnChapterCheckpointSplits.Name = "btnChapterCheckpointSplits";
-            this.btnChapterCheckpointSplits.Size = new System.Drawing.Size(70, 23);
+            this.btnChapterCheckpointSplits.Size = new System.Drawing.Size(140, 44);
             this.btnChapterCheckpointSplits.TabIndex = 2;
             this.btnChapterCheckpointSplits.TabStop = false;
             this.btnChapterCheckpointSplits.Text = "Checkpoint";
@@ -114,29 +133,23 @@
             // 
             // btnABCSides
             // 
-            this.btnABCSides.Location = new System.Drawing.Point(395, 3);
+            this.btnABCSides.Location = new System.Drawing.Point(780, 6);
+            this.btnABCSides.Margin = new System.Windows.Forms.Padding(6);
             this.btnABCSides.Name = "btnABCSides";
-            this.btnABCSides.Size = new System.Drawing.Size(44, 23);
+            this.btnABCSides.Size = new System.Drawing.Size(88, 44);
             this.btnABCSides.TabIndex = 4;
             this.btnABCSides.TabStop = false;
             this.btnABCSides.Text = "A B C";
             this.btnABCSides.UseVisualStyleBackColor = true;
             this.btnABCSides.Click += new System.EventHandler(this.btnABCSides_Click);
             // 
-            // chkHighPriority
+            // toolTip1
             // 
-            this.chkHighPriority.Location = new System.Drawing.Point(170, 3);
-            this.chkHighPriority.Name = "chkHighPriority";
-            this.chkHighPriority.Size = new System.Drawing.Size(83, 23);
-            this.chkHighPriority.TabIndex = 6;
-            this.chkHighPriority.TabStop = false;
-            this.chkHighPriority.Text = "High Priority";
-            this.chkHighPriority.UseVisualStyleBackColor = true;
-            this.chkHighPriority.CheckedChanged += new System.EventHandler(this.ControlChanged);
+            this.toolTip1.AutomaticDelay = 250;
             // 
             // SplitterSettings
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
             this.AutoSize = true;
@@ -144,7 +157,7 @@
             this.Controls.Add(this.flowMain);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "SplitterSettings";
-            this.Size = new System.Drawing.Size(442, 29);
+            this.Size = new System.Drawing.Size(874, 56);
             this.Load += new System.EventHandler(this.Settings_Load);
             this.flowMain.ResumeLayout(false);
             this.flowMain.PerformLayout();
@@ -164,5 +177,6 @@
         private System.Windows.Forms.Button btnABCSides;
         private System.Windows.Forms.CheckBox chkAutoReset;
         private System.Windows.Forms.CheckBox chkHighPriority;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/SplitterSettings.resx
+++ b/SplitterSettings.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
- **Split on cassettes/hearts that have already been collected on a file if using IL splits**
Because the autosplitter previously only monitored the current file's cassette/heart count to fire those types of splits, any runs done on files that had already collected the cassette weren't able to use these splits, which has been a sore point for people in the community for a while - 5A/6A cassette segments are quite popular for Any% practice, and Full Clear/Heart + Cassette ILs have full boards on SRC, but doing any of these types of runs required wiping the file each time the collectible was touched to use the autosplitter. Celeste's `AutoSplitterInfo` class exposes `ChapterCassette` and `ChapterHeart` fields that track whether a cassette/heart has been collected in this session, so the first commit of this PR adds an extra check to cassette/heart splits to use these bools while running on IL splits, since the lifetime of an IL (by SRC rules) is contained to one session under the game's logic.

- **Always update heart/cassette count**
While making the above change, a couple people reported that they had also seen pretty consistent false positives in the past when using heart splits in certain levels, e.g. in 4A during All Hearts runs. We tracked down the cause to the autosplitter not always being aware of a change in collectible count immediately when it occurs, since cassette/heart counts were only being updated when those types of splits were active. It's kinda hard to explain succinctly but e.g. collecting a B-side heart while on a chapter complete autosplit means that the heart is never accounted for (because the switch-case would break and ignore the `default` case, skipping over the cassette/heart calculation), so if the next two autosplits are a checkpoint and then a heart collect, as soon as the checkpoint split fires the heart collect also fires as it only now learns that a heart has been collected. In the case of 4A, runners were collecting the 3B heart while using a chapter complete split, then going into 4A, splitting on entering the 2nd CP and having their subsequent 4A heart split go off for the 3B heart.
If there was a reason why the cassette/heart counts were only being calculated when cassette/heart splits were active then please let me know, I couldn't see one beyond performance so it seemed unnecessary to keep that structure intact.

- **Add clarifying tooltips to Auto Reset ILs and High Priority**
The `Auto Reset ILs` and `High Priority` options were a little ambiguous in their meaning to people and consistently raised questions from newcomers regarding their purpose, so I added some tooltips to them to hopefully help prevent this confusion. I have no idea why VS decided to mess with some of the values in the Designer, the window layout is exactly the same as it was before even with these changes so I guess it's something to do with adding a `ToolTip` (I've never used WinForms before).