### PR TITLE
Add area ID splits + add option to auto set game time + misc.

### DIFF
--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -35,6 +35,9 @@ namespace LiveSplit.Celeste {
                 Model = new TimerModel() { CurrentState = state };
                 Model.InitializeGameTime();
                 Model.CurrentState.IsGameTimePaused = true;
+                if (settings.SetGameTime) {
+                    Model.CurrentState.CurrentTimingMethod = TimingMethod.GameTime;
+                }
                 state.OnReset += OnReset;
                 state.OnPause += OnPause;
                 state.OnResume += OnResume;

--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -110,6 +110,7 @@ namespace LiveSplit.Celeste {
                         case SplitType.LevelEnter: shouldSplit = areaID != Area.Menu && levelName != lastLevelName && levelName.Equals(split.Value, StringComparison.OrdinalIgnoreCase); break;
                         case SplitType.LevelExit: shouldSplit = areaID != Area.Menu && levelName != lastLevelName && lastLevelName.Equals(split.Value, StringComparison.OrdinalIgnoreCase); break;
                         case SplitType.ChapterA: shouldSplit = ChapterSplit(Area.Prologue, Area.Prologue, levelName, completed, elapsed); break;
+                        case SplitType.AreaComplete: shouldSplit = AreaCompleteSplit(split, areaID, areaDifficulty, levelName, completed, elapsed); break;
                         case SplitType.AreaEnter: shouldSplit = AreaChangeSplit(split, areaID, areaID, areaDifficulty, areaDifficulty); break;
                         case SplitType.AreaExit: shouldSplit = AreaChangeSplit(split, areaID, lastAreaID, areaDifficulty, lastAreaDifficulty); break;
                         case SplitType.Prologue: shouldSplit = ChapterSplit(areaID, Area.Prologue, levelName, completed, elapsed); break;
@@ -218,6 +219,14 @@ namespace LiveSplit.Celeste {
                 return exitingChapter && settings.ILSplits;
             }
             return !completed && lastCompleted;
+        }
+        private bool AreaCompleteSplit(SplitInfo split, Area areaID, AreaMode areaDifficulty, string level, bool completed, double elapsed) {
+            string[] splitInfo = split.Value.Split('-');
+            if (Enum.TryParse(splitInfo[0].Trim(), out Area splitAreaID)) {
+                return ChapterSplit(areaID, splitAreaID, level, completed, elapsed) &&
+                    (splitInfo.Length == 1 || (Enum.TryParse(splitInfo[1].Trim(), out AreaMode splitAreaDifficulty) && areaDifficulty == splitAreaDifficulty));
+            }
+            return false;
         }
         private bool AreaChangeSplit(SplitInfo split, Area currAreaID, Area areaIDToCheck, AreaMode currAreaDifficulty, AreaMode areaDifficultyToCheck) {
             string[] splitInfo = split.Value.Split('-');

--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -111,8 +111,8 @@ namespace LiveSplit.Celeste {
                         case SplitType.LevelExit: shouldSplit = areaID != Area.Menu && levelName != lastLevelName && lastLevelName.Equals(split.Value, StringComparison.OrdinalIgnoreCase); break;
                         case SplitType.ChapterA: shouldSplit = ChapterSplit(Area.Prologue, Area.Prologue, levelName, completed, elapsed); break;
                         case SplitType.AreaComplete: shouldSplit = AreaCompleteSplit(split, areaID, levelName, completed, elapsed); break;
-                        case SplitType.AreaEnter: shouldSplit = AreaChangeSplit(split, areaID, areaID, areaDifficulty, areaDifficulty); break;
-                        case SplitType.AreaExit: shouldSplit = AreaChangeSplit(split, areaID, lastAreaID, areaDifficulty, lastAreaDifficulty); break;
+                        case SplitType.AreaOnEnter: shouldSplit = AreaChangeSplit(split, areaID, areaID, areaDifficulty, areaDifficulty); break;
+                        case SplitType.AreaOnExit: shouldSplit = AreaChangeSplit(split, areaID, lastAreaID, areaDifficulty, lastAreaDifficulty); break;
                         case SplitType.Prologue: shouldSplit = ChapterSplit(areaID, Area.Prologue, levelName, completed, elapsed); break;
                         case SplitType.Chapter1: shouldSplit = ChapterSplit(areaID, Area.ForsakenCity, levelName, completed, elapsed); break;
                         case SplitType.Chapter2: shouldSplit = ChapterSplit(areaID, Area.OldSite, levelName, completed, elapsed); break;

--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -222,16 +222,16 @@ namespace LiveSplit.Celeste {
         }
         private bool AreaCompleteSplit(SplitInfo split, Area areaID, string level, bool completed, double elapsed) {
             string[] splitInfo = split.Value.Split('-');
-            if (Enum.TryParse(splitInfo[0].Trim(), out Area splitAreaID)) {
+            if (Enum.TryParse(splitInfo[0].Trim(), true, out Area splitAreaID)) {
                 return ChapterSplit(areaID, splitAreaID, level, completed, elapsed) &&
-                    (splitInfo.Length == 1 || (Enum.TryParse(splitInfo[1].Trim(), out AreaMode splitAreaDifficulty) && lastAreaDifficulty == splitAreaDifficulty));
+                    (splitInfo.Length == 1 || (Enum.TryParse(splitInfo[1].Trim(), true, out AreaMode splitAreaDifficulty) && lastAreaDifficulty == splitAreaDifficulty));
             }
             return false;
         }
         private bool AreaChangeSplit(SplitInfo split, Area currAreaID, Area areaIDToCheck, AreaMode currAreaDifficulty, AreaMode areaDifficultyToCheck) {
             string[] splitInfo = split.Value.Split('-');
-            return Enum.TryParse(splitInfo[0].Trim(), out Area splitAreaID) && currAreaID != lastAreaID && areaIDToCheck == splitAreaID &&
-                (splitInfo.Length == 1 || (Enum.TryParse(splitInfo[1].Trim(), out AreaMode splitAreaDifficulty) && currAreaDifficulty != lastAreaDifficulty && areaDifficultyToCheck == splitAreaDifficulty));
+            return Enum.TryParse(splitInfo[0].Trim(), true, out Area splitAreaID) && currAreaID != lastAreaID && areaIDToCheck == splitAreaID &&
+                (splitInfo.Length == 1 || (Enum.TryParse(splitInfo[1].Trim(), true, out AreaMode splitAreaDifficulty) && currAreaDifficulty != lastAreaDifficulty && areaDifficultyToCheck == splitAreaDifficulty));
         }
         private void HandleSplit(bool shouldSplit, bool shouldReset = false) {
             if (shouldReset) {

--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -95,9 +95,9 @@ namespace LiveSplit.Celeste {
                     lastShowInputUI = chapterStarted;
                 }
             } else {
-                double elapsed = settings.ILSplits ? mem.LevelTime() : mem.GameTime();
                 bool completed = mem.ChapterCompleted();
                 Area areaID = mem.AreaID();
+                double elapsed = settings.ILSplits ? (areaID == Area.Menu ? lastElapsed : mem.LevelTime()) : mem.GameTime();
                 AreaMode areaDifficulty = mem.AreaDifficulty();
                 int addAmount = settings.Splits.Count > 0 && !settings.ChapterSplits ? 1 : 0;
                 SplitInfo split = currentSplit + addAmount < settings.Splits.Count ? settings.Splits[currentSplit + addAmount] : null;

--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -110,7 +110,7 @@ namespace LiveSplit.Celeste {
                         case SplitType.LevelEnter: shouldSplit = areaID != Area.Menu && levelName != lastLevelName && levelName.Equals(split.Value, StringComparison.OrdinalIgnoreCase); break;
                         case SplitType.LevelExit: shouldSplit = areaID != Area.Menu && levelName != lastLevelName && lastLevelName.Equals(split.Value, StringComparison.OrdinalIgnoreCase); break;
                         case SplitType.ChapterA: shouldSplit = ChapterSplit(Area.Prologue, Area.Prologue, levelName, completed, elapsed); break;
-                        case SplitType.AreaComplete: shouldSplit = AreaCompleteSplit(split, areaID, areaDifficulty, levelName, completed, elapsed); break;
+                        case SplitType.AreaComplete: shouldSplit = AreaCompleteSplit(split, areaID, levelName, completed, elapsed); break;
                         case SplitType.AreaEnter: shouldSplit = AreaChangeSplit(split, areaID, areaID, areaDifficulty, areaDifficulty); break;
                         case SplitType.AreaExit: shouldSplit = AreaChangeSplit(split, areaID, lastAreaID, areaDifficulty, lastAreaDifficulty); break;
                         case SplitType.Prologue: shouldSplit = ChapterSplit(areaID, Area.Prologue, levelName, completed, elapsed); break;
@@ -220,11 +220,11 @@ namespace LiveSplit.Celeste {
             }
             return !completed && lastCompleted;
         }
-        private bool AreaCompleteSplit(SplitInfo split, Area areaID, AreaMode areaDifficulty, string level, bool completed, double elapsed) {
+        private bool AreaCompleteSplit(SplitInfo split, Area areaID, string level, bool completed, double elapsed) {
             string[] splitInfo = split.Value.Split('-');
             if (Enum.TryParse(splitInfo[0].Trim(), out Area splitAreaID)) {
                 return ChapterSplit(areaID, splitAreaID, level, completed, elapsed) &&
-                    (splitInfo.Length == 1 || (Enum.TryParse(splitInfo[1].Trim(), out AreaMode splitAreaDifficulty) && areaDifficulty == splitAreaDifficulty));
+                    (splitInfo.Length == 1 || (Enum.TryParse(splitInfo[1].Trim(), out AreaMode splitAreaDifficulty) && lastAreaDifficulty == splitAreaDifficulty));
             }
             return false;
         }

--- a/SplitterObjects.cs
+++ b/SplitterObjects.cs
@@ -47,6 +47,8 @@ namespace LiveSplit.Celeste {
         Manual,
         [Description("Any Chapter (Complete)")]
         ChapterA,
+        [Description("Area (Complete)")]
+        AreaComplete,
         [Description("Area (On Enter)")]
         AreaEnter,
         [Description("Area (On Exit)")]

--- a/SplitterObjects.cs
+++ b/SplitterObjects.cs
@@ -50,9 +50,9 @@ namespace LiveSplit.Celeste {
         [Description("Area (Complete)")]
         AreaComplete,
         [Description("Area (On Enter)")]
-        AreaEnter,
+        AreaOnEnter,
         [Description("Area (On Exit)")]
-        AreaExit,
+        AreaOnExit,
         [Description("Any Heart Gem (Pickup)")]
         HeartGemAny,
         [Description("Level (On Enter)")]

--- a/SplitterObjects.cs
+++ b/SplitterObjects.cs
@@ -47,6 +47,10 @@ namespace LiveSplit.Celeste {
         Manual,
         [Description("Any Chapter (Complete)")]
         ChapterA,
+        [Description("Area (On Enter)")]
+        AreaEnter,
+        [Description("Area (On Exit)")]
+        AreaExit,
         [Description("Any Heart Gem (Pickup)")]
         HeartGemAny,
         [Description("Level (On Enter)")]

--- a/SplitterSettings.Designer.cs
+++ b/SplitterSettings.Designer.cs
@@ -23,15 +23,17 @@
         /// the contents of this method with the code editor.
         /// </summary>
         private void InitializeComponent() {
+            this.components = new System.ComponentModel.Container();
             this.btnAddSplit = new System.Windows.Forms.Button();
             this.flowMain = new System.Windows.Forms.FlowLayoutPanel();
             this.flowOptions = new System.Windows.Forms.FlowLayoutPanel();
             this.chkAutoReset = new System.Windows.Forms.CheckBox();
             this.chkHighPriority = new System.Windows.Forms.CheckBox();
+            this.chkGameTime = new System.Windows.Forms.CheckBox();
             this.btnChapterSplits = new System.Windows.Forms.Button();
             this.btnChapterCheckpointSplits = new System.Windows.Forms.Button();
             this.btnABCSides = new System.Windows.Forms.Button();
-            this.toolTip1 = new System.Windows.Forms.ToolTip();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.flowMain.SuspendLayout();
             this.flowOptions.SuspendLayout();
             this.SuspendLayout();
@@ -42,7 +44,7 @@
             this.btnAddSplit.Location = new System.Drawing.Point(6, 6);
             this.btnAddSplit.Margin = new System.Windows.Forms.Padding(6);
             this.btnAddSplit.Name = "btnAddSplit";
-            this.btnAddSplit.Size = new System.Drawing.Size(59, 23);
+            this.btnAddSplit.Size = new System.Drawing.Size(108, 35);
             this.btnAddSplit.TabIndex = 0;
             this.btnAddSplit.Text = "Add Split";
             this.btnAddSplit.UseVisualStyleBackColor = true;
@@ -59,7 +61,7 @@
             this.flowMain.Location = new System.Drawing.Point(0, 0);
             this.flowMain.Margin = new System.Windows.Forms.Padding(0);
             this.flowMain.Name = "flowMain";
-            this.flowMain.Size = new System.Drawing.Size(874, 56);
+            this.flowMain.Size = new System.Drawing.Size(1052, 56);
             this.flowMain.TabIndex = 0;
             this.flowMain.WrapContents = false;
             this.flowMain.DragDrop += new System.Windows.Forms.DragEventHandler(this.flowMain_DragDrop);
@@ -72,13 +74,14 @@
             this.flowOptions.Controls.Add(this.btnAddSplit);
             this.flowOptions.Controls.Add(this.chkAutoReset);
             this.flowOptions.Controls.Add(this.chkHighPriority);
+            this.flowOptions.Controls.Add(this.chkGameTime);
             this.flowOptions.Controls.Add(this.btnChapterSplits);
             this.flowOptions.Controls.Add(this.btnChapterCheckpointSplits);
             this.flowOptions.Controls.Add(this.btnABCSides);
             this.flowOptions.Location = new System.Drawing.Point(0, 0);
             this.flowOptions.Margin = new System.Windows.Forms.Padding(0);
             this.flowOptions.Name = "flowOptions";
-            this.flowOptions.Size = new System.Drawing.Size(874, 56);
+            this.flowOptions.Size = new System.Drawing.Size(1052, 56);
             this.flowOptions.TabIndex = 0;
             // 
             // chkAutoReset
@@ -107,9 +110,22 @@
             this.chkHighPriority.UseVisualStyleBackColor = true;
             this.chkHighPriority.CheckedChanged += new System.EventHandler(this.ControlChanged);
             // 
+            // chkGameTime
+            // 
+            this.chkGameTime.Location = new System.Drawing.Point(508, 6);
+            this.chkGameTime.Margin = new System.Windows.Forms.Padding(6);
+            this.chkGameTime.Name = "chkGameTime";
+            this.chkGameTime.Size = new System.Drawing.Size(166, 44);
+            this.chkGameTime.TabIndex = 7;
+            this.chkGameTime.TabStop = false;
+            this.chkGameTime.Text = "Game Time";
+            this.toolTip1.SetToolTip(this.chkGameTime, "Automatically set Livesplit to use Game Time");
+            this.chkGameTime.UseVisualStyleBackColor = true;
+            this.chkGameTime.CheckedChanged += new System.EventHandler(this.ControlChanged);
+            // 
             // btnChapterSplits
             // 
-            this.btnChapterSplits.Location = new System.Drawing.Point(508, 6);
+            this.btnChapterSplits.Location = new System.Drawing.Point(686, 6);
             this.btnChapterSplits.Margin = new System.Windows.Forms.Padding(6);
             this.btnChapterSplits.Name = "btnChapterSplits";
             this.btnChapterSplits.Size = new System.Drawing.Size(108, 44);
@@ -121,7 +137,7 @@
             // 
             // btnChapterCheckpointSplits
             // 
-            this.btnChapterCheckpointSplits.Location = new System.Drawing.Point(628, 6);
+            this.btnChapterCheckpointSplits.Location = new System.Drawing.Point(806, 6);
             this.btnChapterCheckpointSplits.Margin = new System.Windows.Forms.Padding(6);
             this.btnChapterCheckpointSplits.Name = "btnChapterCheckpointSplits";
             this.btnChapterCheckpointSplits.Size = new System.Drawing.Size(140, 44);
@@ -133,7 +149,7 @@
             // 
             // btnABCSides
             // 
-            this.btnABCSides.Location = new System.Drawing.Point(780, 6);
+            this.btnABCSides.Location = new System.Drawing.Point(958, 6);
             this.btnABCSides.Margin = new System.Windows.Forms.Padding(6);
             this.btnABCSides.Name = "btnABCSides";
             this.btnABCSides.Size = new System.Drawing.Size(88, 44);
@@ -157,7 +173,7 @@
             this.Controls.Add(this.flowMain);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "SplitterSettings";
-            this.Size = new System.Drawing.Size(874, 56);
+            this.Size = new System.Drawing.Size(1052, 56);
             this.Load += new System.EventHandler(this.Settings_Load);
             this.flowMain.ResumeLayout(false);
             this.flowMain.PerformLayout();
@@ -178,5 +194,6 @@
         private System.Windows.Forms.CheckBox chkAutoReset;
         private System.Windows.Forms.CheckBox chkHighPriority;
         private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.CheckBox chkGameTime;
     }
 }

--- a/SplitterSettings.Designer.cs
+++ b/SplitterSettings.Designer.cs
@@ -61,7 +61,7 @@
             this.flowMain.Location = new System.Drawing.Point(0, 0);
             this.flowMain.Margin = new System.Windows.Forms.Padding(0);
             this.flowMain.Name = "flowMain";
-            this.flowMain.Size = new System.Drawing.Size(1052, 56);
+            this.flowMain.Size = new System.Drawing.Size(680, 112);
             this.flowMain.TabIndex = 0;
             this.flowMain.WrapContents = false;
             this.flowMain.DragDrop += new System.Windows.Forms.DragEventHandler(this.flowMain_DragDrop);
@@ -80,8 +80,9 @@
             this.flowOptions.Controls.Add(this.btnABCSides);
             this.flowOptions.Location = new System.Drawing.Point(0, 0);
             this.flowOptions.Margin = new System.Windows.Forms.Padding(0);
+            this.flowOptions.MaximumSize = new System.Drawing.Size(775, 0);
             this.flowOptions.Name = "flowOptions";
-            this.flowOptions.Size = new System.Drawing.Size(1052, 56);
+            this.flowOptions.Size = new System.Drawing.Size(680, 112);
             this.flowOptions.TabIndex = 0;
             // 
             // chkAutoReset
@@ -125,7 +126,7 @@
             // 
             // btnChapterSplits
             // 
-            this.btnChapterSplits.Location = new System.Drawing.Point(686, 6);
+            this.btnChapterSplits.Location = new System.Drawing.Point(6, 62);
             this.btnChapterSplits.Margin = new System.Windows.Forms.Padding(6);
             this.btnChapterSplits.Name = "btnChapterSplits";
             this.btnChapterSplits.Size = new System.Drawing.Size(108, 44);
@@ -137,7 +138,7 @@
             // 
             // btnChapterCheckpointSplits
             // 
-            this.btnChapterCheckpointSplits.Location = new System.Drawing.Point(806, 6);
+            this.btnChapterCheckpointSplits.Location = new System.Drawing.Point(126, 62);
             this.btnChapterCheckpointSplits.Margin = new System.Windows.Forms.Padding(6);
             this.btnChapterCheckpointSplits.Name = "btnChapterCheckpointSplits";
             this.btnChapterCheckpointSplits.Size = new System.Drawing.Size(140, 44);
@@ -149,7 +150,7 @@
             // 
             // btnABCSides
             // 
-            this.btnABCSides.Location = new System.Drawing.Point(958, 6);
+            this.btnABCSides.Location = new System.Drawing.Point(278, 62);
             this.btnABCSides.Margin = new System.Windows.Forms.Padding(6);
             this.btnABCSides.Name = "btnABCSides";
             this.btnABCSides.Size = new System.Drawing.Size(88, 44);
@@ -173,7 +174,7 @@
             this.Controls.Add(this.flowMain);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "SplitterSettings";
-            this.Size = new System.Drawing.Size(1052, 56);
+            this.Size = new System.Drawing.Size(680, 112);
             this.Load += new System.EventHandler(this.Settings_Load);
             this.flowMain.ResumeLayout(false);
             this.flowMain.PerformLayout();

--- a/SplitterSettings.cs
+++ b/SplitterSettings.cs
@@ -8,7 +8,7 @@ using System.Xml;
 namespace LiveSplit.Celeste {
     public partial class SplitterSettings : UserControl {
         public List<SplitInfo> Splits { get; private set; }
-        public bool ILSplits, ChapterSplits, AutoReset, SetHighPriority;
+        public bool ILSplits, ChapterSplits, AutoReset, SetHighPriority, SetGameTime;
         private bool isLoading;
         public SplitterSettings() {
             isLoading = true;
@@ -19,6 +19,7 @@ namespace LiveSplit.Celeste {
             ChapterSplits = false;
             AutoReset = true;
             SetHighPriority = true;
+            SetGameTime = true;
 
             isLoading = false;
         }
@@ -47,6 +48,7 @@ namespace LiveSplit.Celeste {
 
             chkAutoReset.Checked = AutoReset;
             chkHighPriority.Checked = SetHighPriority;
+            chkGameTime.Checked = SetGameTime;
             isLoading = false;
             this.flowMain.ResumeLayout(true);
         }
@@ -79,6 +81,7 @@ namespace LiveSplit.Celeste {
 
             int chapterCount = 0;
             int heartCount = 0;
+            int cassetteCount = 0;
             Splits.Clear();
             foreach (Control control in flowMain.Controls) {
                 if (control is SplitterSplitSettings) {
@@ -93,14 +96,17 @@ namespace LiveSplit.Celeste {
                             chapterCount++;
                         } else if (type.ToString().IndexOf("HeartGem", StringComparison.OrdinalIgnoreCase) >= 0) {
                             heartCount++;
+                        } else if (type.ToString().IndexOf("Cassette", StringComparison.OrdinalIgnoreCase) >= 0) {
+                            cassetteCount++;
                         }
                     }
                 }
             }
-            ILSplits = Splits.Count == 0 || (chapterCount <= 1 && heartCount <= 1);
-            ChapterSplits = chapterCount > 0 || heartCount > 0;
+            ILSplits = Splits.Count == 0 || (chapterCount <= 1 && heartCount <= 1 && cassetteCount <= 1);
+            ChapterSplits = chapterCount > 0 || heartCount > 0 || cassetteCount > 0;
             AutoReset = chkAutoReset.Checked;
             SetHighPriority = chkHighPriority.Checked;
+            SetGameTime = chkGameTime.Checked;
         }
         public XmlNode UpdateSettings(XmlDocument document) {
             XmlElement xmlSettings = document.CreateElement("Settings");
@@ -112,6 +118,10 @@ namespace LiveSplit.Celeste {
             XmlElement xmlHighPriority = document.CreateElement("SetHighPriority");
             xmlHighPriority.InnerText = SetHighPriority.ToString();
             xmlSettings.AppendChild(xmlHighPriority);
+
+            XmlElement xmlGameTime = document.CreateElement("SetGameTime");
+            xmlGameTime.InnerText = SetGameTime.ToString();
+            xmlSettings.AppendChild(xmlGameTime);
 
             XmlElement xmlSplits = document.CreateElement("Splits");
             xmlSettings.AppendChild(xmlSplits);
@@ -127,6 +137,7 @@ namespace LiveSplit.Celeste {
         public void SetSettings(XmlNode settings) {
             int chapterCount = 0;
             int heartCount = 0;
+            int cassetteCount = 0;
             Splits.Clear();
 
             XmlNode resetNode = settings.SelectSingleNode(".//AutoReset");
@@ -134,6 +145,9 @@ namespace LiveSplit.Celeste {
 
             XmlNode highPriorityNode = settings.SelectSingleNode(".//SetHighPriority");
             SetHighPriority = !string.IsNullOrEmpty(highPriorityNode?.InnerText) ? bool.Parse(highPriorityNode.InnerText) : true;
+
+            XmlNode gameTimeNode = settings.SelectSingleNode(".//SetGameTime");
+            SetGameTime = !string.IsNullOrEmpty(gameTimeNode?.InnerText) ? bool.Parse(gameTimeNode.InnerText) : true;
 
             XmlNodeList splitNodes = settings.SelectNodes(".//Splits/Split");
             foreach (XmlNode splitNode in splitNodes) {
@@ -144,10 +158,12 @@ namespace LiveSplit.Celeste {
                     chapterCount++;
                 } else if (split.Type.ToString().IndexOf("HeartGem", StringComparison.OrdinalIgnoreCase) >= 0) {
                     heartCount++;
+                } else if (split.Type.ToString().IndexOf("Cassette", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    cassetteCount++;
                 }
             }
-            ILSplits = Splits.Count == 0 || (chapterCount <= 1 && heartCount <= 1);
-            ChapterSplits = chapterCount > 0 || heartCount > 0;
+            ILSplits = Splits.Count == 0 || (chapterCount <= 1 && heartCount <= 1 && cassetteCount <= 1);
+            ChapterSplits = chapterCount > 0 || heartCount > 0 || cassetteCount > 0;
         }
         private void btnAddSplit_Click(object sender, EventArgs e) {
             SplitterSplitSettings setting = new SplitterSplitSettings();

--- a/SplitterSettings.cs
+++ b/SplitterSettings.cs
@@ -94,7 +94,7 @@ namespace LiveSplit.Celeste {
                             chapterCount++;
                         } else if (type.ToString().IndexOf("HeartGem", StringComparison.OrdinalIgnoreCase) >= 0) {
                             heartCount++;
-                        } else if (type.ToString().IndexOf("Area", StringComparison.OrdinalIgnoreCase) >= 0) {
+                        } else if (type.ToString().IndexOf("AreaComplete", StringComparison.OrdinalIgnoreCase) >= 0) {
                             areaCount++;
                         }
                     }

--- a/SplitterSettings.cs
+++ b/SplitterSettings.cs
@@ -148,7 +148,7 @@ namespace LiveSplit.Celeste {
                     chapterCount++;
                 } else if (split.Type.ToString().IndexOf("HeartGem", StringComparison.OrdinalIgnoreCase) >= 0) {
                     heartCount++;
-                } else if (split.Type.ToString().IndexOf("Area", StringComparison.OrdinalIgnoreCase) >= 0) {
+                } else if (split.Type.ToString().IndexOf("AreaComplete", StringComparison.OrdinalIgnoreCase) >= 0) {
                     areaCount++;
                 }
             }

--- a/SplitterSettings.cs
+++ b/SplitterSettings.cs
@@ -130,6 +130,7 @@ namespace LiveSplit.Celeste {
         public void SetSettings(XmlNode settings) {
             int chapterCount = 0;
             int heartCount = 0;
+            int areaCount = 0;
             Splits.Clear();
 
             XmlNode resetNode = settings.SelectSingleNode(".//AutoReset");
@@ -147,10 +148,12 @@ namespace LiveSplit.Celeste {
                     chapterCount++;
                 } else if (split.Type.ToString().IndexOf("HeartGem", StringComparison.OrdinalIgnoreCase) >= 0) {
                     heartCount++;
+                } else if (split.Type.ToString().IndexOf("Area", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    areaCount++;
                 }
             }
-            ILSplits = Splits.Count == 0 || (chapterCount <= 1 && heartCount <= 1);
-            ChapterSplits = chapterCount > 0 || heartCount > 0;
+            ILSplits = Splits.Count == 0 || (chapterCount <= 1 && heartCount <= 1 && areaCount <= 1);
+            ChapterSplits = chapterCount > 0 || heartCount > 0 || areaCount > 0;
         }
         private void btnAddSplit_Click(object sender, EventArgs e) {
             SplitterSplitSettings setting = new SplitterSplitSettings();

--- a/SplitterSettings.cs
+++ b/SplitterSettings.cs
@@ -79,6 +79,7 @@ namespace LiveSplit.Celeste {
 
             int chapterCount = 0;
             int heartCount = 0;
+            int areaCount = 0;
             Splits.Clear();
             foreach (Control control in flowMain.Controls) {
                 if (control is SplitterSplitSettings) {
@@ -93,12 +94,14 @@ namespace LiveSplit.Celeste {
                             chapterCount++;
                         } else if (type.ToString().IndexOf("HeartGem", StringComparison.OrdinalIgnoreCase) >= 0) {
                             heartCount++;
+                        } else if (type.ToString().IndexOf("Area", StringComparison.OrdinalIgnoreCase) >= 0) {
+                            areaCount++;
                         }
                     }
                 }
             }
-            ILSplits = Splits.Count == 0 || (chapterCount <= 1 && heartCount <= 1);
-            ChapterSplits = chapterCount > 0 || heartCount > 0;
+            ILSplits = Splits.Count == 0 || (chapterCount <= 1 && heartCount <= 1 && areaCount <= 1);
+            ChapterSplits = chapterCount > 0 || heartCount > 0 || areaCount > 0;
             AutoReset = chkAutoReset.Checked;
             SetHighPriority = chkHighPriority.Checked;
         }

--- a/SplitterSettings.resx
+++ b/SplitterSettings.resx
@@ -120,4 +120,7 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/SplitterSplitSettings.cs
+++ b/SplitterSplitSettings.cs
@@ -22,7 +22,7 @@ namespace LiveSplit.Celeste {
         private void cboType_SelectedIndexChanged(object sender, EventArgs e) {
             string splitDescription = cboType.SelectedValue.ToString();
             SplitType split = GetEnumValue<SplitType>(splitDescription);
-            if (split != SplitType.LevelExit && split != SplitType.LevelEnter) {
+            if (split != SplitType.LevelExit && split != SplitType.LevelEnter && split != SplitType.AreaExit && split != SplitType.AreaEnter) {
                 txtLevel.Visible = false;
                 txtLevel.Text = string.Empty;
                 cboType.Size = new System.Drawing.Size(313, 21);

--- a/SplitterSplitSettings.cs
+++ b/SplitterSplitSettings.cs
@@ -22,7 +22,7 @@ namespace LiveSplit.Celeste {
         private void cboType_SelectedIndexChanged(object sender, EventArgs e) {
             string splitDescription = cboType.SelectedValue.ToString();
             SplitType split = GetEnumValue<SplitType>(splitDescription);
-            if (split != SplitType.LevelExit && split != SplitType.LevelEnter && split != SplitType.AreaComplete && split != SplitType.AreaExit && split != SplitType.AreaEnter) {
+            if (split != SplitType.LevelExit && split != SplitType.LevelEnter && split != SplitType.AreaComplete && split != SplitType.AreaOnExit && split != SplitType.AreaOnEnter) {
                 txtLevel.Visible = false;
                 txtLevel.Text = string.Empty;
                 cboType.Size = new System.Drawing.Size(313, 21);

--- a/SplitterSplitSettings.cs
+++ b/SplitterSplitSettings.cs
@@ -22,7 +22,7 @@ namespace LiveSplit.Celeste {
         private void cboType_SelectedIndexChanged(object sender, EventArgs e) {
             string splitDescription = cboType.SelectedValue.ToString();
             SplitType split = GetEnumValue<SplitType>(splitDescription);
-            if (split != SplitType.LevelExit && split != SplitType.LevelEnter && split != SplitType.AreaExit && split != SplitType.AreaEnter) {
+            if (split != SplitType.LevelExit && split != SplitType.LevelEnter && split != SplitType.AreaComplete && split != SplitType.AreaExit && split != SplitType.AreaEnter) {
                 txtLevel.Visible = false;
                 txtLevel.Text = string.Empty;
                 cboType.Size = new System.Drawing.Size(313, 21);


### PR DESCRIPTION
- **Add area ID splits**
Adds three new splits: `Area (Complete)`, `Area (On Exit)` and `Area (On Enter)`. These are particularly useful for people who wish to split on a return to map (e.g. after 5A cassette collection), on a save and quit (e.g. in 2A going into the last checkpoint), or for custom map runners (e.g. splitting on completing specific maps or on exiting collab lobbies). Two valid forms of input: 
   - `areaID` on its own, where area IDs can either be any positive integer (allowing for custom maps to be recognised) or one of the labels in the `Area` enum (case-insensitive). E.g. `1` would check for any side in Chapter 1, `OldSite` would check for any side in Chapter 2, `celestialresort` would check for any side in Chapter 3.
   - `areaID-areaMode`, where area modes can again be any positive integer or one of the labels in the `AreaMode` enum. E.g. `1-2` would check for specifically Chapter 1 C-Side, `OldSite-BSide` would check for specifically Chapter 2 B-Side, `celestialresort-aside` would check for specifically Chapter 3 A-Side.
- **Add option to auto set game time**
Auto sets Livesplit's comparison to game time when enabled. The primary reason for this is to prevent new runners from getting tripped up by the difference between real and game time when first running with Livesplit - it is one of the more common issues in the Discord from new members, and given how irrelevant real time is in Celeste it was decided to be worth turning on automatically. Livesplit is also a little confusing in how it remembers whether a splits file should use game time (I've personally had it occasionally switch back to real time on me after running other games) so this provides a little bit of QOL too. It is toggleable in case of the rare reason to use real time, and enabled by default to make sure that new runners don't miss it.
- **Include cassette splits in ILSplits/ChapterSplits count**
It's not uncommon for runners to do segments that end on a cassette collection (5A for example), and many people were using weird workarounds like adding dummy chapter complete splits to get Livesplit to act like they were running an IL, so this just gets rid of the need for that and adds support for it directly.
- **Prevent timer from going back to 0:00.00 when exiting a level during IL timing**
This was partly necessary because having the last split of an IL be an `Area (On Exit)` broke and had Livesplit end on 0:00.00 (I think the game wipes the IL timer before updating the area ID when exiting), and partly because there are situations in which runners exit the level and then continue like in 2A (they turn Auto Reset ILs off to do this) and there were no negative side effects that I could find from "pausing" the IL timer when this happens so that it looks less jank. I'll be on the look out for complaints though, since this is the one change that I'm worried about breaking a link in the chain somewhere.