### PR TITLE
"Fix" Area Exit Prologue split misfiring on timer start

### DIFF
--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -115,7 +115,7 @@ namespace LiveSplit.Celeste {
                         case SplitType.ChapterA: shouldSplit = ChapterSplit(Area.Prologue, Area.Prologue, levelName, completed, elapsed); break;
                         case SplitType.AreaComplete: shouldSplit = AreaCompleteSplit(split, areaID, levelName, completed, elapsed); break;
                         case SplitType.AreaOnEnter: shouldSplit = AreaChangeSplit(split, areaID, areaID, areaDifficulty, areaDifficulty); break;
-                        case SplitType.AreaOnExit: shouldSplit = AreaChangeSplit(split, areaID, lastAreaID, areaDifficulty, lastAreaDifficulty); break;
+                        case SplitType.AreaOnExit: shouldSplit = AreaChangeSplit(split, areaID, lastAreaID, areaDifficulty, lastAreaDifficulty) && elapsed >= 0.1; break;
                         case SplitType.Prologue: shouldSplit = ChapterSplit(areaID, Area.Prologue, levelName, completed, elapsed); break;
                         case SplitType.Chapter1: shouldSplit = ChapterSplit(areaID, Area.ForsakenCity, levelName, completed, elapsed); break;
                         case SplitType.Chapter2: shouldSplit = ChapterSplit(areaID, Area.OldSite, levelName, completed, elapsed); break;


### PR DESCRIPTION
An `Area (On Exit)` split that specifically had the value `0` and was the first split in the run was *sometimes* misfiring on timer start in fullgame for reasons that I could not figure out at all, so this is an ugly bandaid to account for this specific issue - there's no reasonable use case I could think of that would be affected by this extra guard at least. Here's a video of the issue in case you have any hunch as to the root cause of it: https://clips.twitch.tv/RenownedModernCroissantUWot-B15DuuasT0eL-Rsb, I couldn't see anything wrong with debug prints or memory watching so I gave up.