### PR TITLE
Actually fix area splits misfiring on timer start

### DIFF
--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -22,8 +22,8 @@ namespace LiveSplit.Celeste {
         private bool hasLog = false, lastShowInputUI, lastCompleted, exitingChapter, autoAdding, autoAddingExit;
         private double lastElapsed, levelTimer;
         private string lastLevelName, levelStarted;
-        private Area lastAreaID;
-        private AreaMode lastAreaDifficulty;
+        private Area lastAreaID = (Area)(-2);
+        private AreaMode lastAreaDifficulty = (AreaMode)(-2);
 
         public SplitterComponent(LiveSplitState state) {
             mem = new SplitterMemory();
@@ -115,7 +115,7 @@ namespace LiveSplit.Celeste {
                         case SplitType.ChapterA: shouldSplit = ChapterSplit(Area.Prologue, Area.Prologue, levelName, completed, elapsed); break;
                         case SplitType.AreaComplete: shouldSplit = AreaCompleteSplit(split, areaID, levelName, completed, elapsed); break;
                         case SplitType.AreaOnEnter: shouldSplit = AreaChangeSplit(split, areaID, areaID, areaDifficulty, areaDifficulty); break;
-                        case SplitType.AreaOnExit: shouldSplit = AreaChangeSplit(split, areaID, lastAreaID, areaDifficulty, lastAreaDifficulty) && elapsed >= 0.1; break;
+                        case SplitType.AreaOnExit: shouldSplit = AreaChangeSplit(split, areaID, lastAreaID, areaDifficulty, lastAreaDifficulty); break;
                         case SplitType.Prologue: shouldSplit = ChapterSplit(areaID, Area.Prologue, levelName, completed, elapsed); break;
                         case SplitType.Chapter1: shouldSplit = ChapterSplit(areaID, Area.ForsakenCity, levelName, completed, elapsed); break;
                         case SplitType.Chapter2: shouldSplit = ChapterSplit(areaID, Area.OldSite, levelName, completed, elapsed); break;
@@ -333,6 +333,8 @@ namespace LiveSplit.Celeste {
             currentSplit = -1;
             exitingChapter = false;
             autoAdding = false;
+            lastAreaID = (Area)(-2);
+            lastAreaDifficulty = (AreaMode)(-2);
             Model.CurrentState.IsGameTimePaused = true;
             WriteLog("---------Reset----------------------------------");
         }


### PR DESCRIPTION
Apologies this took me so long to figure out, but I realised what the issue was - the default value of an enum is 0, so `lastAreaID` was being initialised to 0 or `Area.Prologue` when the splitter component was being created, and so if the first split was Area (On Exit) with a value of 0 then on timer start (while in the main menu) it was checking `-1 != 0 && 0 == 0` and generating a false positive. Thus initialising it to something lower than -1 should sufficiently fix this.

In addition, this false positive could also be seen if the runner reset Livesplit while still in Prologue, since `lastAreaID` would not update until the timer started again, so reverting the variable back to its init state in `OnReset` seemed like the best solution there.

The only way that I can see these splits "breaking" now is if the runner has an Area (On Enter) split as their first split and they start the timer while in that area, because then the check will be `x != -2 && x == x`. I cannot think of any sane way in which this would actually come up, and if it does then there should be an equally valid alternative using an Area (On Exit) split anyway.