### PR TITLE
Add File Time Offset setting

### DIFF
--- a/SplitterComponent.cs
+++ b/SplitterComponent.cs
@@ -20,7 +20,7 @@ namespace LiveSplit.Celeste {
         private SplitterSettings settings;
         private int currentSplit = -1, lastLogCheck, lastHeartGems, lastCassettes;
         private bool hasLog = false, lastShowInputUI, lastCompleted, exitingChapter, autoAdding, autoAddingExit;
-        private double lastElapsed, levelTimer;
+        private double lastElapsed, levelTimer, elapsedOffset;
         private string lastLevelName, levelStarted;
         private Area lastAreaID = (Area)(-2);
         private AreaMode lastAreaDifficulty = (AreaMode)(-2);
@@ -97,7 +97,7 @@ namespace LiveSplit.Celeste {
             } else {
                 bool completed = mem.ChapterCompleted();
                 Area areaID = mem.AreaID();
-                double elapsed = settings.ILSplits ? (areaID == Area.Menu ? lastElapsed : mem.LevelTime()) : mem.GameTime();
+                double elapsed = settings.FileTimeOffset ? mem.GameTime() - elapsedOffset : (settings.ILSplits ? (areaID == Area.Menu ? lastElapsed : mem.LevelTime()) : mem.GameTime());
                 AreaMode areaDifficulty = mem.AreaDifficulty();
                 int addAmount = settings.Splits.Count > 0 && !settings.ChapterSplits ? 1 : 0;
                 SplitInfo split = currentSplit + addAmount < settings.Splits.Count ? settings.Splits[currentSplit + addAmount] : null;
@@ -163,23 +163,23 @@ namespace LiveSplit.Celeste {
                         case SplitType.Chapter9Checkpoint6: shouldSplit = areaID == Area.Farewell && levelName == "i-00"; break;
                         case SplitType.Chapter9Checkpoint7: shouldSplit = areaID == Area.Farewell && levelName == "j-00"; break;
                         case SplitType.Chapter9Checkpoint8: shouldSplit = areaID == Area.Farewell && levelName == "j-16"; break;
-                        case SplitType.HeartGemAny: shouldSplit = (settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1; break;
-                        case SplitType.Chapter1Cassette: shouldSplit = areaID == Area.ForsakenCity && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                        case SplitType.Chapter1HeartGem: shouldSplit = areaID == Area.ForsakenCity && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                        case SplitType.Chapter2Cassette: shouldSplit = areaID == Area.OldSite && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                        case SplitType.Chapter2HeartGem: shouldSplit = areaID == Area.OldSite && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                        case SplitType.Chapter3Cassette: shouldSplit = areaID == Area.CelestialResort && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                        case SplitType.Chapter3HeartGem: shouldSplit = areaID == Area.CelestialResort && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                        case SplitType.Chapter4Cassette: shouldSplit = areaID == Area.GoldenRidge && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                        case SplitType.Chapter4HeartGem: shouldSplit = areaID == Area.GoldenRidge && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                        case SplitType.Chapter5Cassette: shouldSplit = areaID == Area.MirrorTemple && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                        case SplitType.Chapter5HeartGem: shouldSplit = areaID == Area.MirrorTemple && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                        case SplitType.Chapter6Cassette: shouldSplit = areaID == Area.Reflection && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                        case SplitType.Chapter6HeartGem: shouldSplit = areaID == Area.Reflection && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                        case SplitType.Chapter7Cassette: shouldSplit = areaID == Area.TheSummit && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                        case SplitType.Chapter7HeartGem: shouldSplit = areaID == Area.TheSummit && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
-                        case SplitType.Chapter8Cassette: shouldSplit = areaID == Area.Core && ((settings.ILSplits && chapterCassette) || cassettes == lastCassettes + 1); break;
-                        case SplitType.Chapter8HeartGem: shouldSplit = areaID == Area.Core && ((settings.ILSplits && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.HeartGemAny: shouldSplit = ((settings.ILSplits || settings.FileTimeOffset) && chapterHeart) || heartGems == lastHeartGems + 1; break;
+                        case SplitType.Chapter1Cassette: shouldSplit = areaID == Area.ForsakenCity && (((settings.ILSplits || settings.FileTimeOffset) && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter1HeartGem: shouldSplit = areaID == Area.ForsakenCity && (((settings.ILSplits || settings.FileTimeOffset) && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter2Cassette: shouldSplit = areaID == Area.OldSite && (((settings.ILSplits || settings.FileTimeOffset) && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter2HeartGem: shouldSplit = areaID == Area.OldSite && (((settings.ILSplits || settings.FileTimeOffset) && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter3Cassette: shouldSplit = areaID == Area.CelestialResort && (((settings.ILSplits || settings.FileTimeOffset) && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter3HeartGem: shouldSplit = areaID == Area.CelestialResort && (((settings.ILSplits || settings.FileTimeOffset) && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter4Cassette: shouldSplit = areaID == Area.GoldenRidge && (((settings.ILSplits || settings.FileTimeOffset) && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter4HeartGem: shouldSplit = areaID == Area.GoldenRidge && (((settings.ILSplits || settings.FileTimeOffset) && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter5Cassette: shouldSplit = areaID == Area.MirrorTemple && (((settings.ILSplits || settings.FileTimeOffset) && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter5HeartGem: shouldSplit = areaID == Area.MirrorTemple && (((settings.ILSplits || settings.FileTimeOffset) && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter6Cassette: shouldSplit = areaID == Area.Reflection && (((settings.ILSplits || settings.FileTimeOffset) && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter6HeartGem: shouldSplit = areaID == Area.Reflection && (((settings.ILSplits || settings.FileTimeOffset) && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter7Cassette: shouldSplit = areaID == Area.TheSummit && (((settings.ILSplits || settings.FileTimeOffset) && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter7HeartGem: shouldSplit = areaID == Area.TheSummit && (((settings.ILSplits || settings.FileTimeOffset) && chapterHeart) || heartGems == lastHeartGems + 1); break;
+                        case SplitType.Chapter8Cassette: shouldSplit = areaID == Area.Core && (((settings.ILSplits || settings.FileTimeOffset) && chapterCassette) || cassettes == lastCassettes + 1); break;
+                        case SplitType.Chapter8HeartGem: shouldSplit = areaID == Area.Core && (((settings.ILSplits || settings.FileTimeOffset) && chapterHeart) || heartGems == lastHeartGems + 1); break;
                     }
                     lastCassettes = cassettes;
                     lastHeartGems = heartGems;
@@ -347,6 +347,7 @@ namespace LiveSplit.Celeste {
         public void OnStart(object sender, EventArgs e) {
             currentSplit = 0;
             Model.CurrentState.IsGameTimePaused = true;
+            elapsedOffset = mem.GameTime();
             WriteLog("---------New Game " + Assembly.GetExecutingAssembly().GetName().Version.ToString(3) + "-------------------------");
             SplitInfo split = currentSplit < settings.Splits.Count ? settings.Splits[currentSplit] : null;
             if (split != null) {

--- a/SplitterSettings.Designer.cs
+++ b/SplitterSettings.Designer.cs
@@ -29,6 +29,7 @@
             this.flowOptions = new System.Windows.Forms.FlowLayoutPanel();
             this.chkAutoReset = new System.Windows.Forms.CheckBox();
             this.chkHighPriority = new System.Windows.Forms.CheckBox();
+            this.chkFileTimeOffset = new System.Windows.Forms.CheckBox();
             this.chkGameTime = new System.Windows.Forms.CheckBox();
             this.btnChapterSplits = new System.Windows.Forms.Button();
             this.btnChapterCheckpointSplits = new System.Windows.Forms.Button();
@@ -61,7 +62,7 @@
             this.flowMain.Location = new System.Drawing.Point(0, 0);
             this.flowMain.Margin = new System.Windows.Forms.Padding(0);
             this.flowMain.Name = "flowMain";
-            this.flowMain.Size = new System.Drawing.Size(680, 112);
+            this.flowMain.Size = new System.Drawing.Size(880, 112);
             this.flowMain.TabIndex = 0;
             this.flowMain.WrapContents = false;
             this.flowMain.DragDrop += new System.Windows.Forms.DragEventHandler(this.flowMain_DragDrop);
@@ -74,15 +75,16 @@
             this.flowOptions.Controls.Add(this.btnAddSplit);
             this.flowOptions.Controls.Add(this.chkAutoReset);
             this.flowOptions.Controls.Add(this.chkHighPriority);
+            this.flowOptions.Controls.Add(this.chkFileTimeOffset);
             this.flowOptions.Controls.Add(this.chkGameTime);
             this.flowOptions.Controls.Add(this.btnChapterSplits);
             this.flowOptions.Controls.Add(this.btnChapterCheckpointSplits);
             this.flowOptions.Controls.Add(this.btnABCSides);
             this.flowOptions.Location = new System.Drawing.Point(0, 0);
             this.flowOptions.Margin = new System.Windows.Forms.Padding(0);
-            this.flowOptions.MaximumSize = new System.Drawing.Size(775, 0);
+            this.flowOptions.MaximumSize = new System.Drawing.Size(900, 0);
             this.flowOptions.Name = "flowOptions";
-            this.flowOptions.Size = new System.Drawing.Size(680, 112);
+            this.flowOptions.Size = new System.Drawing.Size(880, 112);
             this.flowOptions.TabIndex = 0;
             // 
             // chkAutoReset
@@ -103,7 +105,7 @@
             this.chkHighPriority.Location = new System.Drawing.Point(330, 6);
             this.chkHighPriority.Margin = new System.Windows.Forms.Padding(6);
             this.chkHighPriority.Name = "chkHighPriority";
-            this.chkHighPriority.Size = new System.Drawing.Size(166, 44);
+            this.chkHighPriority.Size = new System.Drawing.Size(163, 44);
             this.chkHighPriority.TabIndex = 6;
             this.chkHighPriority.TabStop = false;
             this.chkHighPriority.Text = "High Priority";
@@ -111,12 +113,26 @@
             this.chkHighPriority.UseVisualStyleBackColor = true;
             this.chkHighPriority.CheckedChanged += new System.EventHandler(this.ControlChanged);
             // 
+            // chkFileTimeOffset
+            // 
+            this.chkFileTimeOffset.Location = new System.Drawing.Point(505, 6);
+            this.chkFileTimeOffset.Margin = new System.Windows.Forms.Padding(6);
+            this.chkFileTimeOffset.Name = "chkFileTimeOffset";
+            this.chkFileTimeOffset.Size = new System.Drawing.Size(198, 44);
+            this.chkFileTimeOffset.TabIndex = 8;
+            this.chkFileTimeOffset.TabStop = false;
+            this.chkFileTimeOffset.Text = "File Time Offset";
+            this.toolTip1.SetToolTip(this.chkFileTimeOffset, "Use file time, offsetting the timer to start at 0\r\nUseful for running file time s" +
+        "egments without a new save file\r\nNot necessary for full game runs");
+            this.chkFileTimeOffset.UseVisualStyleBackColor = true;
+            this.chkFileTimeOffset.CheckedChanged += new System.EventHandler(this.ControlChanged);
+            // 
             // chkGameTime
             // 
-            this.chkGameTime.Location = new System.Drawing.Point(508, 6);
+            this.chkGameTime.Location = new System.Drawing.Point(715, 6);
             this.chkGameTime.Margin = new System.Windows.Forms.Padding(6);
             this.chkGameTime.Name = "chkGameTime";
-            this.chkGameTime.Size = new System.Drawing.Size(166, 44);
+            this.chkGameTime.Size = new System.Drawing.Size(159, 44);
             this.chkGameTime.TabIndex = 7;
             this.chkGameTime.TabStop = false;
             this.chkGameTime.Text = "Game Time";
@@ -163,6 +179,9 @@
             // toolTip1
             // 
             this.toolTip1.AutomaticDelay = 250;
+            this.toolTip1.AutoPopDelay = 32000;
+            this.toolTip1.InitialDelay = 250;
+            this.toolTip1.ReshowDelay = 50;
             // 
             // SplitterSettings
             // 
@@ -174,7 +193,7 @@
             this.Controls.Add(this.flowMain);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "SplitterSettings";
-            this.Size = new System.Drawing.Size(680, 112);
+            this.Size = new System.Drawing.Size(880, 112);
             this.Load += new System.EventHandler(this.Settings_Load);
             this.flowMain.ResumeLayout(false);
             this.flowMain.PerformLayout();
@@ -196,5 +215,6 @@
         private System.Windows.Forms.CheckBox chkHighPriority;
         private System.Windows.Forms.ToolTip toolTip1;
         private System.Windows.Forms.CheckBox chkGameTime;
+        private System.Windows.Forms.CheckBox chkFileTimeOffset;
     }
 }

--- a/SplitterSettings.cs
+++ b/SplitterSettings.cs
@@ -8,7 +8,7 @@ using System.Xml;
 namespace LiveSplit.Celeste {
     public partial class SplitterSettings : UserControl {
         public List<SplitInfo> Splits { get; private set; }
-        public bool ILSplits, ChapterSplits, AutoReset, SetHighPriority, SetGameTime;
+        public bool ILSplits, ChapterSplits, AutoReset, SetHighPriority, SetGameTime, FileTimeOffset;
         private bool isLoading;
         public SplitterSettings() {
             isLoading = true;
@@ -20,6 +20,7 @@ namespace LiveSplit.Celeste {
             AutoReset = true;
             SetHighPriority = true;
             SetGameTime = true;
+            FileTimeOffset = false;
 
             isLoading = false;
         }
@@ -49,6 +50,7 @@ namespace LiveSplit.Celeste {
             chkAutoReset.Checked = AutoReset;
             chkHighPriority.Checked = SetHighPriority;
             chkGameTime.Checked = SetGameTime;
+            chkFileTimeOffset.Checked = FileTimeOffset;
             isLoading = false;
             this.flowMain.ResumeLayout(true);
         }
@@ -107,9 +109,17 @@ namespace LiveSplit.Celeste {
             }
             ILSplits = Splits.Count == 0 || (chapterCount <= 1 && heartCount <= 1 && areaCount <= 1 && cassetteCount <= 1);
             ChapterSplits = chapterCount > 0 || heartCount > 0 || areaCount > 0 || cassetteCount > 0;
-            AutoReset = chkAutoReset.Checked;
+
             SetHighPriority = chkHighPriority.Checked;
             SetGameTime = chkGameTime.Checked;
+
+            if (chkAutoReset.Checked && !AutoReset) {
+                chkFileTimeOffset.Checked = false;
+            } else if (chkFileTimeOffset.Checked && !FileTimeOffset) {
+                chkAutoReset.Checked = false;
+            }
+            AutoReset = chkAutoReset.Checked;
+            FileTimeOffset = chkFileTimeOffset.Checked;
         }
         public XmlNode UpdateSettings(XmlDocument document) {
             XmlElement xmlSettings = document.CreateElement("Settings");
@@ -125,6 +135,10 @@ namespace LiveSplit.Celeste {
             XmlElement xmlGameTime = document.CreateElement("SetGameTime");
             xmlGameTime.InnerText = SetGameTime.ToString();
             xmlSettings.AppendChild(xmlGameTime);
+
+            XmlElement xmlFileTimeOffset = document.CreateElement("FileTimeOffset");
+            xmlFileTimeOffset.InnerText = FileTimeOffset.ToString();
+            xmlSettings.AppendChild(xmlFileTimeOffset);
 
             XmlElement xmlSplits = document.CreateElement("Splits");
             xmlSettings.AppendChild(xmlSplits);
@@ -152,6 +166,9 @@ namespace LiveSplit.Celeste {
 
             XmlNode gameTimeNode = settings.SelectSingleNode(".//SetGameTime");
             SetGameTime = !string.IsNullOrEmpty(gameTimeNode?.InnerText) ? bool.Parse(gameTimeNode.InnerText) : true;
+
+            XmlNode fileTimeOffsetNode = settings.SelectSingleNode(".//FileTimeOffset");
+            FileTimeOffset = !string.IsNullOrEmpty(fileTimeOffsetNode?.InnerText) ? bool.Parse(fileTimeOffsetNode.InnerText) : false;
 
             XmlNodeList splitNodes = settings.SelectNodes(".//Splits/Split");
             foreach (XmlNode splitNode in splitNodes) {


### PR DESCRIPTION
Adds a setting that locks to file time, taking the value of the file timer at timer start and using that to offset the time elapsed calculations from then on. Primarily useful for running splits where you want to use file time but don’t want a new save file (multi-chapter segments, levels that use return to map strats like 1ARB, etc).

Additional behaviours:
- Enables the IL cassette/heart splitting behaviour, since this can (and will primarily) be used for running on an existing save file and thus regular cassette/heart detection won’t work.
- Negates Auto Reset ILs (and vice versa) to avoid people getting confused when their timer resets if they exit the level despite using the file timer. It’s probably possible to edit the splits file manually to force these to both be true, but at that point I think it’s fair to say they know what they’re doing and to let it happen.